### PR TITLE
 Bug 907805 - [email] Add plaintext escaping functions to bleach.js

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -293,7 +293,7 @@ HTMLSanitizer.prototype = {
         this.complete = true;
       }
     } else {
-      this.output += escapeHTMLEntities(text);
+      this.output += escapeHTMLTextKeepingExistingEntities(text);
     }
   },
 
@@ -945,7 +945,11 @@ function makeReverseEntities () {
   });
 }
 
-function escapeHTMLEntities(text) {
+/**
+ * Escapes HTML characters like [<>"'&] in the text,
+ * leaving existing HTML entities intact.
+ */
+function escapeHTMLTextKeepingExistingEntities(text) {
   return text.replace(/[<>"']|&(?![#a-zA-Z0-9]+;)/g, function(c) {
     return '&#' + c.charCodeAt(0) + ';';
   });
@@ -975,5 +979,28 @@ exports.unescapeHTMLEntities = function unescapeHTMLEntities(text) {
     return converted;
   });
 };
+
+/**
+ * Renders text content safe for injecting into HTML by
+ * replacing all characters which could be used to create HTML elements.
+ */
+exports.escapePlaintextIntoElementContext = function (text) {
+  return text.replace(/[&<>"'\/]/g, function(c) {
+    var code = c.charCodeAt(0);
+    return '&' + (entities[code] || '#' + code) + ';';
+  });
+}
+
+/**
+ * Escapes all characters with ASCII values less than 256, other than
+ * alphanumeric characters, with the &#xHH; format to prevent
+ * switching out of the attribute.
+ */
+exports.escapePlaintextIntoAttribute = function (text) {
+  return text.replace(/[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u0100]/g, function(c) {
+    return '&#' + c.charCodeAt(0) + ';';
+  });
+}
+
 
 }); // end define

--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -998,7 +998,8 @@ exports.escapePlaintextIntoElementContext = function (text) {
  */
 exports.escapePlaintextIntoAttribute = function (text) {
   return text.replace(/[\u0000-\u002F\u003A-\u0040\u005B-\u0060\u007B-\u0100]/g, function(c) {
-    return '&#' + c.charCodeAt(0) + ';';
+    var code = c.charCodeAt(0);
+    return '&' + (entities[code] || '#' + code) + ';';
   });
 }
 

--- a/test/test-escape-plaintext.js
+++ b/test/test-escape-plaintext.js
@@ -1,0 +1,25 @@
+var mocha = require('mocha')
+  , bleach = require('../')
+  , should = require('should');
+
+describe('bleach', function () {
+  describe('escaping', function () {
+    it('should escape plaintext for elements', function() {
+      bleach.escapePlaintextIntoElementContext([
+        '<p>a <strong>"simple"',
+        '</strong> example</p>'
+      ].join('\n')).should.equal([
+        '&lt;p&gt;a &lt;strong&gt;&quot;simple&quot;',
+        '&lt;&#47;strong&gt; example&lt;&#47;p&gt;'
+      ].join('\n'));
+    });
+    
+    it('should escape plaintext for attributes', function() {
+      bleach.escapePlaintextIntoAttribute([
+        'try">\'to escape'
+      ].join('\n')).should.equal([
+        'try&#34;&#62;&#39;to&#32;escape'
+      ].join('\n'));
+    });
+  });
+});

--- a/test/test-escape-plaintext.js
+++ b/test/test-escape-plaintext.js
@@ -18,7 +18,7 @@ describe('bleach', function () {
       bleach.escapePlaintextIntoAttribute([
         'try">\'to escape'
       ].join('\n')).should.equal([
-        'try&#34;&#62;&#39;to&#32;escape'
+        'try&quot;&gt;&apos;to&#32;escape'
       ].join('\n'));
     });
   });


### PR DESCRIPTION
bleach.escapePlaintextIntoElementContext neutralizes all HTML characters;
bleach.escapePlaintextIntoAttribute renders text safe for inserting into an attribute.
