### PR TITLE
Added funtionality for 'blessing' attributes

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -200,8 +200,7 @@ HTMLSanitizer.prototype = {
     for (var i = 0; i < attrs.length; i++) {
       var attr = attrs[i];
       var attrName = attr.name.toLowerCase();
-
-      if (wildAttrs.indexOf(attrName) !== -1 ||
+      if (attr.safe || wildAttrs.indexOf(attrName) !== -1 ||
           (whitelist && whitelist.indexOf(attrName) !== -1)) {
         if (attrName == "style") {
           var attrValue = '';
@@ -563,7 +562,8 @@ var HTMLParser = (function(){
           attrs.push({
             name: name,
             value: value,
-            escaped: value.replace(/"/g, '&quot;')
+            escaped: value.replace(/"/g, '&quot;'),
+            safe: false
           });
         });
 

--- a/test/test-unclean.js
+++ b/test/test-unclean.js
@@ -264,6 +264,7 @@ var mocha = require('mocha'),
 var RE_CID_URL = /^cid:/i;
 var RE_HTTP_URL = /^http(?:s)?/i;
 var RE_MAILTO_URL = /^mailto:/i;
+var RE_DATA_URL = /^data:/i;
 var RE_IMG_TAG = /^img$/;
 function getAttributeFromList(attrs, name) {
   var len = attrs.length;
@@ -316,6 +317,9 @@ function stashLinks(lowerTag, attrs) {
           classAttr.escaped += ' moz-external-image';
         else
           attrs.push({ name: 'class', escaped: 'moz-external-image' });
+      }
+      else if (RE_DATA_URL.test(srcAttr.escaped)){
+        srcAttr.safe = true;
       }
     }
   }

--- a/test/unclean/expected/safe-attributes.html
+++ b/test/unclean/expected/safe-attributes.html
@@ -1,0 +1,1 @@
+<img src="data:image/png;base64,MakeDataAttributesSafe"/>

--- a/test/unclean/safe-attributes.html
+++ b/test/unclean/safe-attributes.html
@@ -1,0 +1,1 @@
+<img src="data:image/png;base64,MakeDataAttributesSafe"/>


### PR DESCRIPTION
As suggested by asuth, I have added in the ability to designate attributes not on the whitelist as safe in the callback function. You do this by setting attr.safe = true.
