### PR TITLE
Bug 1091310 - block-type tags inside a tags should be wrapped by the a tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
+test/tag-matching/output
+test/snippets/output
 test/unclean/output
 *~

--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -395,8 +395,28 @@ var HTMLParser = (function(){
   // - Block Elements - HTML 4.01
   var block = makeMap("address,applet,blockquote,button,center,dd,del,dir,div,dl,dt,fieldset,form,frameset,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,p,pre,script,table,tbody,td,tfoot,th,thead,tr,ul");
 
-  // - Inline Elements - HTML 4.01
-  var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
+  // - Inline Elements - HTML 4.01, With the exception of "a", bug 1091310.
+  // The "close inline if current tag is block" used in bleach is now a bit out
+  // of date with the HTML parsing definition:
+  // https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody
+  // Specifically, native "inline" vs "block" elements are not primary branch
+  // points in closing logic, but it is very tag-specific. The most notable
+  // point  is that p elements should be closed more often by those rules than
+  // what is done here, and 'a' elements are not treated special when wrapping
+  // a "block" element.. And in the case of
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1091310
+  // specifically, there is no special closing behavior when encountering a
+  // table start tag, except to close any previously open p tag.
+  // Complete removal of the "block" and "inline" checking for closed tags was
+  // considered to fix bug 1091310, and to match more closely the behavior in
+  // the spec document. However:
+  // - we are currently looking at limiting the amount of changes for a possible
+  //   uplift to a more stable branch in gaia
+  // - There are still some notable inconsistencies with the spec, like this
+  //   code not closing of p tags in the same way.
+  // - These lists have things like iframe, object, and script in them, and want
+  //   to really think through the possible impact of the change in behavior.
+  var inline = makeMap("abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
 
   // - Elements that you can, intentionally, leave open (and close themselves)
   var closeSelf = makeMap("colgroup,dd,dt,li,options,p,td,tfoot,th,thead,tr");

--- a/test/dirscan.js
+++ b/test/dirscan.js
@@ -1,0 +1,40 @@
+/**
+ * Scans a directory for test files that end in .html. The contents of those
+ * files will be read in, as well as a matching testDirName/expected version,
+ * and then returned in a structure that can be used to pass to bleach calls for
+ * tests.
+ *
+ * @param {String} dirName The directory name to look into. Relative to
+ * the directory containing this file.
+ *
+ * @return {Object}
+ */
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(testDirName) {
+  'use strict';
+
+  var results = [];
+  var names = [];
+
+  var files = fs.readdirSync(path.join(__dirname, testDirName));
+  files.forEach(function(filename) {
+    var match = /^(.+)\.html$/.exec(filename);
+    if (match)
+      names.push(match[1]);
+  });
+
+  names.forEach(function (name) {
+    var sourcePath = path.join(__dirname , testDirName, name) + '.html',
+        expectedPath = path.join(__dirname, testDirName, 'expected', name) +
+                                 '.html';
+    results.push({
+      name: name,
+      source: fs.readFileSync(sourcePath, 'utf8'),
+      expected: fs.readFileSync(expectedPath, 'utf8')
+    });
+  });
+
+  return results;
+};

--- a/test/snippets/expected/table-interior.html
+++ b/test/snippets/expected/table-interior.html
@@ -1,0 +1,1 @@
+     Confirm Your Account     

--- a/test/snippets/table-interior.html
+++ b/test/snippets/table-interior.html
@@ -1,0 +1,34 @@
+<table>
+  <tr>
+    <td colspan="3" style="">
+      <a ext-href="http://ex.co/a" class="cta_btn moz-external-link">
+        </a><table cellspacing="0" cellpadding="0" width="100%" bgcolor="#4c649b" class="btn_confirm">
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td width="38">
+              &nbsp;</td>
+            <td width="100%">
+              <a ext-href="http://ex.co/a" class="moz-external-link">
+                </a><center>
+                  <font size="4">
+                    <span>
+                      Confirm&nbsp;Your&nbsp;Account</span>
+                  </font>
+                </center>
+
+            </td>
+            <td width="38">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+        </table>
+
+    </td>
+  </tr>
+</table>

--- a/test/tag-matching/a-table-interior.html
+++ b/test/tag-matching/a-table-interior.html
@@ -1,0 +1,34 @@
+<table>
+  <tr>
+    <td colspan="3" style="">
+      <a href="http://ex.co/a" class="cta_btn">
+        <table cellspacing="0" cellpadding="0" width="100%" bgcolor="#4c649b" class="btn_confirm">
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td width="38">
+              &nbsp;</td>
+            <td width="100%">
+              <a href="http://ex.co/a">
+                <center>
+                  <font size="4">
+                    <span>
+                      Confirm&nbsp;Your&nbsp;Account</span>
+                  </font>
+                </center>
+              </a>
+            </td>
+            <td width="38">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+        </table>
+      </a>
+    </td>
+  </tr>
+</table>

--- a/test/tag-matching/expected/a-table-interior.html
+++ b/test/tag-matching/expected/a-table-interior.html
@@ -1,0 +1,34 @@
+<table>
+  <tr>
+    <td colspan="3" style="">
+      <a ext-href="http://ex.co/a" class="cta_btn moz-external-link">
+        <table cellspacing="0" cellpadding="0" width="100%" bgcolor="#4c649b" class="btn_confirm">
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td width="38">
+              &nbsp;</td>
+            <td width="100%">
+              <a ext-href="http://ex.co/a" class="moz-external-link">
+                <center>
+                  <font size="4">
+                    <span>
+                      Confirm&nbsp;Your&nbsp;Account</span>
+                  </font>
+                </center>
+              </a>
+            </td>
+            <td width="38">
+              &nbsp;</td>
+          </tr>
+          <tr>
+            <td height="14" colspan="3">
+              &nbsp;</td>
+          </tr>
+        </table>
+      </a>
+    </td>
+  </tr>
+</table>

--- a/test/test-tag-matching.js
+++ b/test/test-tag-matching.js
@@ -1,21 +1,26 @@
 var mocha = require('mocha'),
-    fs = require('fs'),
-    path = require('path'),
-    exists = fs.existsSync || path.existsSync,
     bleach = require('../'),
     should = require('should'),
     dirscan = require('./dirscan'),
+    fs = require('fs'),
+    path = require('path'),
+    exists = fs.existsSync || path.existsSync,
     options = require('./unclean-options');
 
 describe('bleach', function () {
-  describe('unclean', function () {
 
-    var outPath = path.join(__dirname, 'unclean', 'output');
+  /**
+   * Tests the use of <a> tags around
+   * @return {[type]}
+   */
+  describe('tag-matching', function () {
+
+    var outPath = path.join(__dirname, 'tag-matching', 'output');
     if (!exists(outPath)) {
       fs.mkdirSync(outPath, 511);
     }
 
-    dirscan('unclean').forEach(function (test) {
+    dirscan('tag-matching').forEach(function (test) {
       it(test.name, function () {
         var result = bleach.clean(test.source, options);
 

--- a/test/unclean-options.js
+++ b/test/unclean-options.js
@@ -1,0 +1,354 @@
+var options = {
+  tags: [
+    'a', 'abbr', 'acronym', 'area', 'article', 'aside',
+    // annoying: 'audio',
+    'b',
+    'bdi', 'bdo', // (bidirectional markup stuff)
+    'big', 'blockquote',
+    // implicitly-nuked: 'body'
+    'br',
+    // forms: 'button',
+    // scripty: canvas
+    'caption',
+    'center',
+    'cite', 'code', 'col', 'colgroup',
+    // interactive-ui: 'command',
+    // forms: 'datalist',
+    'dd', 'del', 'details', 'dfn', 'dir', 'div', 'dl', 'dt',
+    'em',
+    // forms: 'fieldset' (but allowed by nsTreeSanitizer)
+    'figcaption', 'figure',
+    'font',
+    'footer',
+    // forms: 'form',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    // non-body: 'head'
+    'header', 'hgroup', 'hr',
+    // non-body: 'html'
+    'i', 'img',
+    // forms: 'input',
+    'ins', // ("represents a range of text that has been inserted to a document")
+    'kbd', // ("The kbd element represents user input")
+    'label', 'legend', 'li',
+    // dangerous: link (for CSS styles
+    /* link supports many types, none of which we want, some of which are
+     * risky: http://dev.w3.org/html5/spec/links.html#linkTypes. Specifics:
+     * - "stylesheet": This would be okay for cid links, but there's no clear
+     *   advantage over inline styles, so we forbid it, especially as supporting
+     *   it might encourage other implementations to dangerously support link.
+     * - "prefetch": Its whole point is de facto information leakage.
+     */
+    'listing', // (deprecated, like "pre")
+    'map', 'mark',
+    // interactive-ui: 'menu', 'meta', 'meter',
+    'nav',
+    'nobr', // (deprecated "white-space:nowrap" equivalent)
+    'noscript',
+    'ol',
+    // forms: 'optgroup',
+    // forms: 'option',
+    'output', // (HTML5 draft: "result of a calculation in a form")
+    'p', 'pre',
+    // interactive-ui: 'progress',
+    'q',
+    /* http://www.w3.org/TR/ruby/ is a pronounciation markup that is not directly
+     * supported by gecko at this time (although there is a Firefox extension).
+     * All of 'rp', 'rt', and 'ruby' are ruby tags.  The spec also defines 'rb'
+     * and 'rbc' tags that nsTreeSanitizer does not whitelist, however.
+     */
+    'rp', 'rt', 'ruby',
+    's', 'samp', 'section',
+    // forms: 'select',
+    'small',
+    // annoying?: 'source',
+    'span', 'strike', 'strong',
+    'style',
+    'sub', 'summary', 'sup',
+    // svg: 'svg', NB: this lives in its own namespace
+    'table', 'tbody', 'td',
+    // forms: 'textarea',
+    'tfoot', 'th', 'thead', 'time',
+    'title', // XXX does this mean anything outside head?
+    'tr',
+    // annoying?: 'track'
+    'tt',
+    'u', 'ul', 'var',
+    // annoying: 'video',
+    'wbr' // (HTML5 draft: line break opportunity)
+  ],
+  strip: true,
+  stripComments: true,
+  prune: [
+    'button', // (forms)
+    'datalist', // (forms)
+    'script', // (script)
+    'select', // (forms)
+    'svg', // (svg)
+    'title', // (non-body)
+  ],
+  attributes: {
+    '*': [
+      'abbr', // (tables: removed from HTML5)
+      // forms: 'accept', 'accept-charset',
+      // interactive-ui: 'accesskey',
+      // forms: 'action',
+      'align', // (pres)
+      'alt', // (fallback content)
+      // forms: 'autocomplete', 'autofocus',
+      // annoying: 'autoplay',
+      'axis', // (tables: removed from HTML5)
+      // URL-like: 'background',
+      'bgcolor', 'border', // (pres)
+      'cellpadding', 'cellspacing', // (pres)
+      // unsupported: 'char',
+      'charoff', // (tables)
+      // specific: 'charset'
+      // forms, interactive-ui: 'checked',
+      // URL-like: 'cite'
+      'class', 'clear', 'color', // (pres)
+      'cols', 'colspan', // (tables)
+      'compact', // (pres)
+      // dangerous: 'content', (meta content refresh is bad.)
+      // interactive-ui: 'contenteditable', (we already use this ourselves!)
+      // interactive-ui: 'contextmenu',
+      // annoying: 'controls', (media)
+      'coords', // (area image map)
+      'datetime', // (ins, del, time semantic markups)
+      // forms: 'disabled',
+      'dir', // (rtl)
+      // interactive-ui: 'draggable',
+      // forms: 'enctype',
+      'face', // (pres)
+      // forms: 'for',
+      'frame', // (tables)
+      'headers', // (tables)
+      'height', // (layout)
+      // interactive-ui: 'hidden', 'high',
+      // sanitized: 'href',
+      // specific: 'hreflang',
+      'hspace', // (pres)
+      // dangerous: 'http-equiv' (meta refresh, maybe other trickiness)
+      // interactive-ui: 'icon',
+      'id', // (pres; white-listed for style targets)
+      // specific: 'ismap', (area image map)
+      // microformat: 'itemid', 'itemprop', 'itemref', 'itemscope', 'itemtype',
+      // annoying: 'kind', (media)
+      // annoying, forms, interactive-ui: 'label',
+      'lang', // (language support)
+      // forms: 'list',
+      // dangerous: 'longdesc', (link to a long description, html5 removed)
+      // annoying: 'loop',
+      // interactive-ui: 'low',
+      // forms, interactive-ui: 'max',
+      // forms: 'maxlength',
+      'media', // (media-query for linky things; safe if links are safe)
+      // forms: 'method',
+      // forms, interactive-ui: 'min',
+      // unsupported: 'moz-do-not-send', (thunderbird internal composition)
+      // forms: 'multiple',
+      // annoying: 'muted',
+      // forms, interactive-ui: 'name', (although pretty safe)
+      'nohref', // (image maps)
+      // forms: 'novalidate',
+      'noshade', // (pres)
+      'nowrap', // (tables)
+      'open', // (for "details" element)
+      // interactive-ui: 'optimum',
+      // forms: 'pattern', 'placeholder',
+      // annoying: 'playbackrate',
+      'pointsize', // (pres)
+      // annoying:  'poster', 'preload',
+      // forms: 'prompt',
+      'pubdate', // ("time" element)
+      // forms: 'radiogroup', 'readonly',
+      // dangerous: 'rel', (link rel, a rel, area rel)
+      // forms: 'required',
+      // awkward: 'rev' (reverse link; you can't really link to emails)
+      'reversed', // (pres? "ol" reverse numbering)
+      // interactive-ui: 'role', We don't want a screen reader making the user
+      //   think that part of the e-mail is part of the UI.  (WAI-ARIA defines
+      //   "accessible rich internet applications", not content markup.)
+      'rows', 'rowspan', 'rules', // (tables)
+      // sanitized: 'src',
+      'size', // (pres)
+      'scope', // (tables)
+      'scoped', // (pres; on "style" elem)
+      // forms: 'selected',
+      'shape', // (image maps)
+      'span', // (tables)
+      // interactive-ui: 'spellcheck',
+      // sanitized, dangerous: 'src'
+      // annoying: 'srclang',
+      'start', // (pres? "ol" numbering)
+      'summary', // (tables accessibility)
+      'style', // (pres)
+      // interactive-ui: 'tabindex',
+      // dangerous: 'target', (specifies a browsing context, but our semantics
+      //   are extremely clear and don't need help.)
+      'title', // (advisory)
+      // specific, dangerous: type (various, but mime-type for links is not the
+      //   type of thing we would ever want to propagate or potentially deceive
+      //   the user with.)
+      'valign', // (pres)
+      'value', // (pres? "li" override for "ol"; various form uses)
+      'vspace', // (pres)
+      'width', // (layout)
+      // forms: 'wrap',
+    ],
+    'a': ['ext-href', 'hreflang'],
+    'area': ['ext-href', 'hreflang'],
+    // these are used by our quoting and Thunderbird's quoting
+    'blockquote': ['cite', 'type'],
+    'img': ['cid-src', 'ext-src', 'ismap', 'usemap'],
+    // This may only end up being used as a debugging thing, but let's let charset
+    // through for now.
+    'meta': ['charset'],
+    'ol': ['type'], // (pres)
+    'style': ['type'],
+  },
+  styles: [
+    // animation: animation*
+    // URI-like: background, background-image
+    'background-color',
+    // NB: border-image is not set by the 'border' aliases
+    'border',
+    'border-bottom', 'border-bottom-color', 'border-bottom-left-radius',
+    'border-bottom-right-radius', 'border-bottom-style', 'border-bottom-width',
+    'border-color',
+    // URI-like: border-image*
+    'border-left', 'border-left-color', 'border-left-style', 'border-left-width',
+    'border-radius',
+    'border-right', 'border-right-color', 'border-right-style',
+    'border-right-width',
+    'border-style',
+    'border-top', 'border-top-color', 'border-top-left-radius',
+    'border-top-right-radius', 'border-top-style', 'border-top-width',
+    'border-width',
+    // slow: box-shadow
+    'clear',
+    'color',
+    'display',
+    'float',
+    'font-family',
+    'font-size',
+    'font-style',
+    'font-weight',
+    'height',
+    'line-height',
+    // URI-like: list-style, list-style-image
+    'list-style-position',
+    'list-style-type',
+    'margin', 'margin-bottom', 'margin-left', 'margin-right', 'margin-top',
+    'padding', 'padding-bottom', 'padding-left', 'padding-right', 'padding-top',
+    'text-align', 'text-align-last',
+    'text-decoration', 'text-decoration-color', 'text-decoration-line',
+    'text-decoration-style', 'text-indent',
+    'vertical-align',
+    'white-space',
+    'width',
+    'word-break', 'word-spacing', 'word-wrap',
+  ],
+  asNode: true,
+  callbackRegexp: /^(?:a|area|img)$/,
+  callback: stashLinks
+};
+
+
+var RE_CID_URL = /^cid:/i;
+var RE_HTTP_URL = /^http(?:s)?/i;
+var RE_MAILTO_URL = /^mailto:/i;
+var RE_DATA_URL = /^data:/i;
+var RE_IMG_TAG = /^img$/;
+function getAttributeFromList(attrs, name) {
+  var len = attrs.length;
+  for (var i = 0; i < len; i++) {
+    var attr = attrs[i];
+    if (attr.name.toLowerCase() === name) {
+      return attr;
+    }
+  }
+  return null;
+}
+
+/**
+ * Transforms src tags, ensure that links are http and transform them too so
+ * that they don't actually navigate when clicked on but we can hook them.  (The
+ * HTML display iframe is not intended to navigate; we just want to trigger the
+ * browser.
+ */
+function stashLinks(lowerTag, attrs) {
+  var classAttr;
+  // - img: src
+  if (RE_IMG_TAG.test(lowerTag)) {
+    // filter out things we might write to, also find the 'class attr'
+    attrs = attrs.filter(function(attr) {
+      switch (attr.name.toLowerCase()) {
+        case 'cid-src':
+        case 'ext-src':
+          return false;
+        case 'class':
+          classAttr = attr;
+        default:
+          return true;
+      }
+    });
+
+    var srcAttr = getAttributeFromList(attrs, 'src');
+    if (srcAttr) {
+      if (RE_CID_URL.test(srcAttr.escaped)) {
+        srcAttr.name = 'cid-src';
+        if (classAttr)
+          classAttr.escaped += ' moz-embedded-image';
+        else
+          attrs.push({ name: 'class', escaped: 'moz-embedded-image' });
+        // strip the cid: bit, it is necessarily there and therefore redundant.
+        srcAttr.escaped = srcAttr.escaped.substring(4);
+      }
+      else if (RE_HTTP_URL.test(srcAttr.escaped)) {
+        srcAttr.name = 'ext-src';
+        if (classAttr)
+          classAttr.escaped += ' moz-external-image';
+        else
+          attrs.push({ name: 'class', escaped: 'moz-external-image' });
+      }
+      else if (RE_DATA_URL.test(srcAttr.escaped)){
+        srcAttr.safe = true;
+      }
+    }
+  }
+  // - a, area: href
+  else {
+    // filter out things we might write to, also find the 'class attr'
+    attrs = attrs.filter(function(attr) {
+      switch (attr.name.toLowerCase()) {
+        case 'cid-src':
+        case 'ext-src':
+          return false;
+        case 'class':
+          classAttr = attr;
+        default:
+          return true;
+      }
+    });
+    var linkAttr = getAttributeFromList(attrs, 'href');
+    if (linkAttr) {
+      var link = linkAttr.escaped;
+      if (RE_HTTP_URL.test(link) ||
+          RE_MAILTO_URL.test(link)) {
+
+        linkAttr.name = 'ext-href';
+        if (classAttr)
+          classAttr.escaped += ' moz-external-link';
+        else
+          attrs.push({ name: 'class', escaped: 'moz-external-link' });
+      }
+      else {
+        // paranoia; no known benefit if this got through
+        attrs.splice(attrs.indexOf(linkAttr), 1);
+      }
+    }
+  }
+  return attrs;
+}
+
+module.exports = options;


### PR DESCRIPTION
Most of the changes in this pull request are test file-related. The only substantive code change is removing 'a', from the `inline` makeMap list.

More notes in lib/bleach.js for the reasoning for choosing that fix. 

These inline vs block distinction for closing tags is out of date with the parsing spec. For a while locally, I was running with just removing the entire block and inline lists and that inline/block comparison in the code, as I do not think it helps so much now. However, being more conservative in the changes are probably best for now.

For 'a' tags, by removing it from the inline map, which is only used for this "if current tag is a block, if previous is an inline, close it" test, the worse case outcome is that more of the message gets hyperlinked.

That is likely the result in an email client that is renders the HTML in a modern HTML renderer. For the gaia email app, we also ask the user before following a hyperlink, but bug 1082604 may change that behavior.
